### PR TITLE
Clarify empty PSCommander config startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,15 @@ Install-Commander
 
 ## Configuration
 
-PSCommander is configured using a single PS1 file. This file is stored within your documents folder. To create a new config file, you can use the following command.
+PSCommander is configured using a single PS1 file. This file is stored within your documents folder at `Documents\PSCommander\config.ps1`. To create the file with a starter configuration and open it in the editor, run:
 
 ```powershell
-$Documents = [Environment]::GetFolderPath('MyDocuments')
-$Commander = Join-Path $Documents 'PSCommander'
-New-Item $Commander -ItemType Directory 
-New-Item (Join-Path $Commander 'config.ps1')
+Start-Commander
 ```
 
-PSCommander will use this configuration file to load settings. Any changes to the file will result in PSCommander reconfiguring itself. If you don't have PSCommander running yet, you can use `Start-Commander`.
+PSCommander will use this configuration file to load settings. Add commands such as `New-CommanderSchedule`, `New-CommanderHotKey`, or `New-CommanderToolbarIcon` directly to `config.ps1`. Running those commands in a regular PowerShell session returns configuration objects for that session; it does not automatically save them to `config.ps1`.
+
+If you create an empty `config.ps1` manually, `Start-Commander` will add a starter toolbar icon configuration the first time it sees the empty file. Any changes to the file will result in PSCommander reconfiguring itself. If you don't have PSCommander running yet, you can use `Start-Commander`.
 
 ```powershell
 Start-Commander 

--- a/pscommander/PSCommander.psm1
+++ b/pscommander/PSCommander.psm1
@@ -421,14 +421,30 @@ function Start-Commander {
         $ConfigPath = [IO.Path]::Combine($Documents, 'PSCommander', 'config.ps1')
     }
 
+    $ConfigDirectory = Split-Path -Path $ConfigPath -Parent
+    $DefaultConfiguration = @"
+New-CommanderToolbarIcon -MenuItem @(
+    New-CommanderMenuItem -Text 'Documentation' -Action {
+        Start-Process 'https://docs.poshtools.com/powershell-pro-tools-documentation/pscommander'
+    }
+)
+"@
+
+    $OpenConfigEditor = $false
+
     if (-not (Test-Path $ConfigPath)) {
         Write-Warning "Configuration file for PSCommander not found. Creating config file..."
-        New-Item -Path (Join-Path $Documents 'PSCommander') -ItemType Directory -Force -ErrorAction SilentlyContinue | Out-Null
-        "New-CommanderToolbarIcon -MenuItem @( 
-    New-CommanderMenuItem -Text 'Documentation' -Action { 
-        Start-Process 'https://docs.poshtools.com/powershell-pro-tools-documentation/pscommander' 
-    } 
-)" | Out-File $ConfigPath 
+        New-Item -Path $ConfigDirectory -ItemType Directory -Force | Out-Null
+        Set-Content -Path $ConfigPath -Value $DefaultConfiguration -Encoding UTF8
+        $OpenConfigEditor = $true
+    }
+    elseif ((Get-Item -Path $ConfigPath).Length -eq 0) {
+        Write-Warning "Configuration file for PSCommander is empty. Adding starter configuration..."
+        Set-Content -Path $ConfigPath -Value $DefaultConfiguration -Encoding UTF8
+        $OpenConfigEditor = $true
+    }
+
+    if ($OpenConfigEditor) {
         Start-Process -FilePath "$PSScriptRoot\psscriptpad.exe" -ArgumentList @("-c `"$ConfigPath`"")
     }
 


### PR DESCRIPTION
Starting PSCommander with a manually created empty `config.ps1` looked like nothing happened, because the starter configuration was only written when the file was missing. This makes the empty-file path behave like first-run setup and updates the README to explain that configuration commands should be saved in `config.ps1`.

Changes:
- Write the default starter toolbar configuration when `Start-Commander` finds an empty config file.
- Keep opening the config editor for newly created or newly seeded configs.
- Clarify that running `New-Commander*` commands in an interactive session does not automatically persist them to `config.ps1`.

Closes #1