### PR TITLE
Migrate PSCommander tooling and CI to .NET 10

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,11 +5,11 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": ".NET Core Launch (console)",
+            "name": ".NET Launch PSCommander",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/pscommander/bin/Debug/net6.0-windows/win10-x64/publish/pscommander.dll",
+            "program": "${workspaceFolder}/pscommander/bin/Debug/net10.0-windows/pscommander.dll",
             "args": [],
             "cwd": "${workspaceFolder}",
             "console": "internalConsole",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,8 +6,8 @@
             "command": "dotnet",
             "type": "process",
             "args": [
-                "publish",
-                "./pscommander.csproj",
+                "build",
+                "${workspaceFolder}/pscommander/pscommander.csproj",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],
@@ -22,7 +22,7 @@
             "type": "process",
             "args": [
                 "publish",
-                "./pscommander.csproj",
+                "${workspaceFolder}/pscommander/pscommander.csproj",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],
@@ -37,14 +37,15 @@
             "type": "process",
             "args": [
                 "watch",
+                "--project",
+                "${workspaceFolder}/pscommander/pscommander.csproj",
                 "run",
-                "./pscommander.csproj",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],
             "problemMatcher": "$msCompile",
             "options": {
-                "cwd": "${workspaceFolder}/pscommander"
+                "cwd": "${workspaceFolder}"
             }
         }
     ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ PSCommander is a Windows desktop automation tool distributed as a PowerShell mod
 
 The solution has two projects:
 
-- `pscommander\pscommander.csproj`: .NET 6 Windows WPF executable and bundled `PSCommander.psm1` / `PSCommander.psd1` module files.
+- `pscommander\pscommander.csproj`: .NET 10 Windows WPF executable and bundled `PSCommander.psm1` / `PSCommander.psd1` module files.
 - `pscommander.models\pscommander.models.csproj`: `netstandard2.0` shared model types returned from the PowerShell module and consumed by the WPF app.
 
 ## Important files and directories
@@ -20,7 +20,7 @@ The solution has two projects:
 - `pscommander\MainWindow.xaml.cs`: composition root. Instantiates services, initializes the PowerShell runspace, loads config, starts event providers, and performs update checks.
 - `pscommander\Services\`: Windows integration, PowerShell runspace, persistence, tray menu, widgets, jobs, named pipes, and configuration reload services.
 - `pscommander.models\`: public model classes and enums used by both PowerShell functions and app services.
-- `.github\workflows\ci.yml`: CI publishes the solution on `windows-latest` with .NET 6.
+- `.github\workflows\ci.yml`: CI publishes the solution on `windows-latest` with .NET 10.
 - `.github\workflows\production.yml`: manual release workflow publishes the module.
 
 ## Build and validation


### PR DESCRIPTION
## Summary
- Upgrade PSCommander from .NET 6 to .NET 10
- Replace the legacy solution with `PSCommander.slnx`
- Update CI, release, and VS Code configurations
- Refresh PowerShell SDK and Newtonsoft.Json dependencies

## Testing
- Not run (not requested)