### PR TITLE
Open the config editor in VS Code with a Notepad fallback

### DIFF
--- a/pscommander/Services/MenuService.cs
+++ b/pscommander/Services/MenuService.cs
@@ -6,7 +6,6 @@ using System.Windows.Media.Imaging;
 using System;
 using System.Management.Automation;
 using System.IO;
-using System.Reflection;
 using System.Drawing;
 
 namespace pscommander
@@ -26,9 +25,6 @@ namespace pscommander
 
         public void UpdateToolbar(ToolbarIcon icon)
         {
-            var assemblyLocation = Assembly.GetEntryAssembly().Location;
-            var fileInfo = new FileInfo(assemblyLocation);
-
             _taskbarIcon.Dispatcher.Invoke(() => {
 
                 if (string.IsNullOrEmpty(icon.Text))
@@ -84,7 +80,7 @@ namespace pscommander
 
                         AddMenuItem(_taskbarIcon.ContextMenu.Items, new MenuItem {
                             Text = "Edit Config",
-                            Action = ScriptBlock.Create($". '{Path.Combine(fileInfo.DirectoryName, "PSScriptPad.exe")}' -c '{path}'")
+                            Action = CreateEditConfigAction(path)
                         });
                     }
 
@@ -98,6 +94,29 @@ namespace pscommander
                 };
                 _taskbarIcon.MenuActivation = PopupActivationMode.RightClick;
             });
+        }
+
+        private static ScriptBlock CreateEditConfigAction(string path)
+        {
+            var escapedPath = EscapePowerShellSingleQuotedString(path);
+            var script = $@"
+$configPath = '{escapedPath}'
+$code = Get-Command -Name code.cmd, code.exe, code -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+
+if ($code) {{
+    Start-Process -FilePath $code.Source -ArgumentList @('-n', $configPath)
+}}
+else {{
+    Start-Process -FilePath notepad.exe -ArgumentList @($configPath)
+}}
+";
+
+            return ScriptBlock.Create(script);
+        }
+
+        private static string EscapePowerShellSingleQuotedString(string value)
+        {
+            return value.Replace("'", "''");
         }
 
         private void AddMenuItem(ItemCollection items, MenuItem item)


### PR DESCRIPTION
## Summary
- Replace the bundled PSScriptPad editor with VS Code when available
- Fall back to Notepad if VS Code is not installed
- Escape config paths safely in the generated PowerShell action

## Testing
- Not run (not requested)