### PR TITLE
Update the module version to 2026.1.0

### DIFF
--- a/pscommander/PSCommander.psd1
+++ b/pscommander/PSCommander.psd1
@@ -12,7 +12,7 @@
     RootModule         = 'PSCommander.psm1'
 
     # Version number of this module.
-    ModuleVersion      = '2022.11.0'
+    ModuleVersion      = '2026.1.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
## Summary
- Update the PSCommander module version from 2022.11.0 to 2026.1.0

## Testing
- Not run (not requested)